### PR TITLE
Fix StableWrapperDrawer null reference when no visible children

### DIFF
--- a/Packages/com.fullmetalbagel.unity-stable-reference/Editor/StableWrapperDrawer.cs
+++ b/Packages/com.fullmetalbagel.unity-stable-reference/Editor/StableWrapperDrawer.cs
@@ -9,13 +9,15 @@ namespace UnityStableReference.Editor
     {
         public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
         {
-            property = property.GetVisibleChildren().Single();
+            property = property.GetVisibleChildren().SingleOrDefault();
+            if (property == null) return 0;
             return EditorGUI.GetPropertyHeight(property, includeChildren: true);
         }
 
         public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
         {
-            property = property.GetVisibleChildren().Single();
+            property = property.GetVisibleChildren().SingleOrDefault();
+            if (property == null) return;
             EditorGUI.PropertyField(position, property, label, includeChildren: true);
         }
     }

--- a/Packages/com.fullmetalbagel.unity-stable-reference/package.json
+++ b/Packages/com.fullmetalbagel.unity-stable-reference/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.fullmetalbagel.unity-stable-reference",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "displayName": "Unity Stable Reference",
   "unity": "2022.3",
   "samples": [


### PR DESCRIPTION
## Summary
- Fix null reference exception in `StableWrapperDrawer` when `GetVisibleChildren()` returns no elements
- Use `SingleOrDefault()` instead of `Single()` with null checks for graceful handling
- Bump package version to 1.1.2

## Test plan
- [ ] Open Unity project with StableReference fields
- [ ] Verify drawer renders correctly for valid references
- [ ] Verify no exceptions when visible children are empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)