### PR TITLE
Fix StableWrapperDrawer error for types without visible children

### DIFF
--- a/Assets/Scripts/Foo.cs
+++ b/Assets/Scripts/Foo.cs
@@ -19,6 +19,15 @@ public class FooImpl1 : IFoo
     }
 }
 
+[Serializable, Guid("35FE2D63-412D-41AA-9F0D-BB3416F11235"), StableWrapperCodeGen]
+public class FooImpl3 : IFoo
+{
+    public void Print()
+    {
+        Debug.Log("FooImpl3");
+    }
+}
+
 [Serializable, Guid("3DDC5AB5-736A-4691-9208-B5641C9E7DE5"), StableWrapperCodeGen]
 public class FooImpl2 : IFoo
 {

--- a/Packages/com.fullmetalbagel.unity-stable-reference/Editor/StableWrapperDrawer.cs
+++ b/Packages/com.fullmetalbagel.unity-stable-reference/Editor/StableWrapperDrawer.cs
@@ -9,16 +9,25 @@ namespace UnityStableReference.Editor
     {
         public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
         {
-            property = property.GetVisibleChildren().SingleOrDefault();
-            if (property == null) return 0;
+            property = property.GetVisibleChildren().Single();
+            if (!HasAnyChild(property)) return EditorGUIUtility.singleLineHeight;
             return EditorGUI.GetPropertyHeight(property, includeChildren: true);
         }
 
         public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
         {
-            property = property.GetVisibleChildren().SingleOrDefault();
-            if (property == null) return;
+            property = property.GetVisibleChildren().Single();
+            if (!HasAnyChild(property))
+            {
+                EditorGUI.LabelField(position, label.text);
+                return;
+            }
             EditorGUI.PropertyField(position, property, label, includeChildren: true);
+        }
+
+        private static bool HasAnyChild(SerializedProperty property)
+        {
+            return property.GetVisibleChildren().Any();
         }
     }
 }

--- a/Packages/com.fullmetalbagel.unity-stable-reference/package.json
+++ b/Packages/com.fullmetalbagel.unity-stable-reference/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.fullmetalbagel.unity-stable-reference",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "displayName": "Unity Stable Reference",
   "unity": "2022.3",
   "samples": [


### PR DESCRIPTION
## Summary
- Fix Unity's "managed reference index out of bounds" error in `StableWrapperDrawer`
- Check if property has any visible children before calling `EditorGUI` APIs
- Bump package version to 1.1.3

## Test plan
- [x] Verify types without serializable fields (like `FooImpl3`) render without errors
- [ ] Verify types with fields still render correctly in inspector

🤖 Generated with [Claude Code](https://claude.com/claude-code)